### PR TITLE
Fix overstripping of command prefix.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -148,7 +148,7 @@ class Plugin extends AbstractPlugin
         $message = $eventParams['text'];
         if ($identity) {
             if (preg_match($identity, $message, $match)) {
-                $message = str_replace($match[0], '', $message);
+                $message = preg_replace($identity, '', $message);
             } elseif (preg_match($this->channelPattern, $target)) {
                 return;
             }


### PR DESCRIPTION
Fixes stripping of the command prefix from other parts of the message:

As an example, assuming `!` is the prefix, or `/^!/` is the pattern, the command parameter to `!addquote "Hello there!"` would be parsed as "Hello there".

Cheers!
