### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ See Phergie documentation for more information on installing plugins.
 ```php
 new \Phergie\Irc\Plugin\React\Command\Plugin(array(
 
-    // All configuration is optional
+    // Select how you'd like the command to be triggered. 
+    // Only 1 method supported at a time so make sure to remove unused methods.
 
     'prefix' => '!', // string denoting the start of a command
 


### PR DESCRIPTION
Clear up some confusion in the docs. It's not optional to have more than 1 item defined because it simply wont work. You can't have more than 1 method of calling the command.

setting a config 
    array(
        'prefix' => '!',
        'nick' => false
    )

would not work as expected since the config is checking for isset on the nick and not checking the other rules.